### PR TITLE
Expose interfaces to GenericType

### DIFF
--- a/graphene_django_extras/base_types.py
+++ b/graphene_django_extras/base_types.py
@@ -32,7 +32,7 @@ def factory_type(operation, _type, *args, **kwargs):
                 registry = kwargs.get('registry')
                 skip_registry = kwargs.get('skip_registry')
                 description = 'Auto generated Type for {} model'.format(kwargs.get('model')._meta.verbose_name)
-                interfaces = kwargs.get('interfaces')
+                interfaces = kwargs.get('interfaces', ())
 
         return GenericType
 

--- a/graphene_django_extras/base_types.py
+++ b/graphene_django_extras/base_types.py
@@ -32,6 +32,7 @@ def factory_type(operation, _type, *args, **kwargs):
                 registry = kwargs.get('registry')
                 skip_registry = kwargs.get('skip_registry')
                 description = 'Auto generated Type for {} model'.format(kwargs.get('model')._meta.verbose_name)
+                interfaces = kwargs.get('interfaces')
 
         return GenericType
 

--- a/graphene_django_extras/types.py
+++ b/graphene_django_extras/types.py
@@ -311,7 +311,7 @@ class DjangoSerializerType(ObjectType):
     def __init_subclass_with_meta__(cls, serializer_class=None, queryset=None, only_fields=(), exclude_fields=(),
                                     pagination=None, input_field_name=None, output_field_name=None,
                                     results_field_name=None, nested_fields=False, filter_fields=None, description='',
-                                    filterset_class=None, **options):
+                                    filterset_class=None, interfaces=(), **options):
 
         if not serializer_class:
             raise Exception('serializer_class is required on all ModelSerializerType')
@@ -350,6 +350,7 @@ class DjangoSerializerType(ObjectType):
             'skip_registry': False,
             'filterset_class': filterset_class,
             'results_field_name': results_field_name,
+            'interfaces': interfaces,
         }
 
         output_type = registry.get_type_for_model(model)
@@ -393,7 +394,7 @@ class DjangoSerializerType(ObjectType):
         _meta.input_field_name = input_field_name
         _meta.output_field_name = output_field_name
 
-        super(DjangoSerializerType, cls).__init_subclass_with_meta__(_meta=_meta, description=description, **options)
+        super(DjangoSerializerType, cls).__init_subclass_with_meta__(_meta=_meta, description=description, interfaces=interfaces, **options)
 
     @classmethod
     def list_object_type(cls):


### PR DESCRIPTION
@Chris7 This enables graphene interfaces to be used with GenericType, and can be used to add non-model fields to the object type.

example:
```
class MyInterface(graphene.Interface):
  my_field = graphene.String()

  def resolve_my_field(self, *args, **kwargs):
    return "foo"


class SomeModelType(DjangoSerializerType):

  class Meta:
    serializer_class = SomeModelSerializer
    filterset_class = SomeModelFilter
    interfaces = (MyInterface,)
```